### PR TITLE
Fix crash on empty markers file

### DIFF
--- a/src/main/java/com/replaymod/replaystudio/replay/AbstractReplayFile.java
+++ b/src/main/java/com/replaymod/replaystudio/replay/AbstractReplayFile.java
@@ -218,6 +218,9 @@ public abstract class AbstractReplayFile implements ReplayFile {
         if (in.isPresent()) {
             try (Reader is = new InputStreamReader(in.get())) {
                 JsonArray json = new Gson().fromJson(is, JsonArray.class);
+                if (json == null) {
+                    return Optional.absent();
+                }
                 Set<Marker> markers = new HashSet<>();
                 for (JsonElement element : json) {
                     JsonObject obj = element.getAsJsonObject();


### PR DESCRIPTION
The current implementation assumes that Gson always returns a valid JsonArray instance. But in the case of an empty file, the result is null, which crashes the game with an NPE. This PR simply adds a null-check to return an empty result as if the file wasn't present.