### PR TITLE
ViaVersion+ViaBackwards fix

### DIFF
--- a/src/main/java/com/replaymod/replaystudio/protocol/registry/DimensionType.java
+++ b/src/main/java/com/replaymod/replaystudio/protocol/registry/DimensionType.java
@@ -110,7 +110,7 @@ public class DimensionType {
         if (registries == null) {
             return new DimensionType(name);
         }
-        Registries.Entry entry = registries.getEntry("minecraft:dimension_type", name);
+        Registries.Entry entry = registries.getEntry("dimension_type", name);
         if (entry == null) {
             return new DimensionType(name);
         }
@@ -118,7 +118,7 @@ public class DimensionType {
     }
 
     public static DimensionType fromRegistry(Registries registries, int id) {
-        Registries.Entry entry = registries.getEntry("minecraft:dimension_type", id);
+        Registries.Entry entry = registries.getEntry("dimension_type", id);
         if (entry == null) {
             return new DimensionType(new CompoundTag(), "", id);
         }

--- a/src/main/java/com/replaymod/replaystudio/protocol/registry/Registries.java
+++ b/src/main/java/com/replaymod/replaystudio/protocol/registry/Registries.java
@@ -54,12 +54,15 @@ public class Registries {
     public Entry getEntry(String registryName, String entryName) {
         if (registriesTag != null) {
             CompoundTag registry = registriesTag.get(registryName);
+            if (registry == null) {
+                registry = registriesTag.get("minecraft:" + registryName);
+            }
             if (registry == null) return null;
             ListTag entries = registry.get("value");
             if (entries == null) return null;
             for (Tag entry : entries) {
                 StringTag name = ((CompoundTag) entry).get("name");
-                if (name != null && name.getValue().equals(entryName)) {
+                if (name != null && (name.getValue().equals(entryName) || name.getValue().equals("minecraft:" + entryName))) {
                     NumberTag id = ((CompoundTag) entry).get("id");
                     Tag value = ((CompoundTag) entry).get("element");
                     return new Entry(id == null ? 0 : id.asInt(), name.getValue(), value);
@@ -85,6 +88,9 @@ public class Registries {
     public Entry getEntry(String registryName, int entryId) {
         if (registriesTag != null) {
             CompoundTag registry = registriesTag.get(registryName);
+            if (registry == null) {
+                registry = registriesTag.get("minecraft:" + registryName);
+            }
             if (registry == null) return null;
             ListTag entries = registry.get("value");
             if (entries == null) return null;


### PR DESCRIPTION
try to get registry entry with and without minecraft namespace.
ViaVersion and ViaBackwards provide it without, and the minecraft client uses the default `minecraft` namespace when deserializing the packet, so it doesnt cause any issues, but replaymod does:
dimension type tag: minecraft:dimension_type
dimension name: overworld
while ViaVersion/ViaBackwards provide:
dimension type tag: dimension_type
dimension name: minecraft:overworld

this does appear to be a viaversion issue, but since easier to fix it here, and not possibly disrupt other mods

vanilla:
<img width="373" height="215" alt="image" src="https://github.com/user-attachments/assets/86476d9d-22f6-4909-858b-87394065e330" />

viaversion:

<img width="461" height="307" alt="image" src="https://github.com/user-attachments/assets/d257e701-86ff-4d56-af9d-97cb43829892" />
